### PR TITLE
Fragebogen zur Bell-Score-Berechnung

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ WordPress-Plugin zum täglichen Erfassen von Bell-Score, emotionalem Zustand, Sy
 - **Tabellenbereinigung:** Unter *Einstellungen → MECFS Tracker* kann festgelegt werden, ob die Datenbanktabellen bei Deaktivierung des Plugins gelöscht werden (`mecfs_tracker_cleanup`).
 
 ## Bell-Score und emotionaler Zustand
-Der Bell-Score beschreibt die allgemeine Belastbarkeit auf einer Skala von 0–100. Für diese erste Version erfolgt die Eingabe manuell über einen Schieberegler.
+Der Bell-Score beschreibt die allgemeine Belastbarkeit auf einer Skala von 0–100. Im Formular wird er über einen kurzen Fragebogen ermittelt. 
 
-Der emotionale Zustand wird ebenfalls über einen Schieberegler von 0–100 erfasst. Eine detaillierte Berechnungsgrundlage kann in späteren Versionen durch Fragebögen ergänzt werden.
+Der emotionale Zustand wird weiterhin über einen Schieberegler von 0–100 erfasst.
+
+### Berechnungsgrundlage
+Der Fragebogen besteht aus fünf Fragen, die jeweils von 0 (schlechtester Zustand) bis 4 (bester Zustand) bewertet werden:
+
+1. Wie belastbar fühlen Sie sich heute körperlich?
+2. Wie gut können Sie heute mentale Aufgaben bewältigen?
+3. Wie oft müssen Sie sich heute ausruhen?
+4. Wie weit können Sie sich heute außer Haus bewegen?
+5. Wie gut sind Ihre Symptome heute kontrollierbar?
+
+Die Antworten werden summiert, durch die maximale Punktzahl (5 Fragen × 4 Punkte = 20) geteilt und auf eine Skala von 0–100 hochgerechnet:
+
+```
+Bell-Score = (Summe der Antworten / 20) × 100
+```

--- a/assets/form.css
+++ b/assets/form.css
@@ -3,3 +3,10 @@
     flex-direction: column;
     gap: 1rem;
 }
+.bell-question {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+}
+.bell-question label {
+    margin-right: 0.5rem;
+}

--- a/assets/form.js
+++ b/assets/form.js
@@ -1,6 +1,18 @@
 jQuery(function ($) {
     $('#mecfs-tracker-form').on('submit', function (e) {
         e.preventDefault();
+        let sum = 0;
+        const questions = 5;
+        for (let i = 1; i <= questions; i++) {
+            const val = parseInt($('input[name="bell_q' + i + '"]:checked').val(), 10);
+            if (isNaN(val)) {
+                alert('Bitte alle Fragen beantworten.');
+                return;
+            }
+            sum += val;
+        }
+        const bell = Math.round((sum / (questions * 4)) * 100);
+        $('input[name="bell_score"]').val(bell);
         const data = $(this).serialize();
         $.post(MECFSTracker.ajax, data + '&action=mecfs_save_entry&nonce=' + MECFSTracker.nonce)
             .done(() => alert('Gespeichert'))

--- a/includes/class-frontend-form.php
+++ b/includes/class-frontend-form.php
@@ -27,8 +27,26 @@ class Frontend_Form {
         ?>
         <form id="mecfs-tracker-form">
             <input type="date" name="entry_date" value="<?php echo esc_attr( current_time( 'Y-m-d' ) ); ?>" />
-            <label><?php esc_html_e( 'Bell-Score', 'mecfs-tracker' ); ?></label>
-            <input type="range" name="bell_score" min="0" max="100" />
+            <?php
+            $questions = [
+                __( 'Wie belastbar fühlen Sie sich heute körperlich?', 'mecfs-tracker' ),
+                __( 'Wie gut können Sie heute mentale Aufgaben bewältigen?', 'mecfs-tracker' ),
+                __( 'Wie oft müssen Sie sich heute ausruhen?', 'mecfs-tracker' ),
+                __( 'Wie weit können Sie sich heute außer Haus bewegen?', 'mecfs-tracker' ),
+                __( 'Wie gut sind Ihre Symptome heute kontrollierbar?', 'mecfs-tracker' ),
+            ];
+            foreach ( $questions as $index => $question ) :
+                ?>
+                <fieldset class="bell-question">
+                    <legend><?php echo esc_html( $question ); ?></legend>
+                    <?php for ( $i = 0; $i <= 4; $i++ ) : ?>
+                        <label><input type="radio" name="bell_q<?php echo $index + 1; ?>" value="<?php echo $i; ?>" required /> <?php echo $i; ?></label>
+                    <?php endfor; ?>
+                </fieldset>
+                <?php
+            endforeach;
+            ?>
+            <input type="hidden" name="bell_score" value="0" />
             <label><?php esc_html_e( 'Emotionaler Zustand', 'mecfs-tracker' ); ?></label>
             <input type="range" name="emotion" min="0" max="100" />
             <!-- TODO: Dynamische Symptome -->


### PR DESCRIPTION
## Summary
- Bell-Score-Eingabe durch fünfteiligen Fragebogen ersetzt.
- JavaScript berechnet Bell-Score automatisch aus den Antworten.
- README um Berechnungsgrundlage des Fragebogens ergänzt.

## Testing
- `php -l includes/class-frontend-form.php`
- `node --check assets/form.js`


------
https://chatgpt.com/codex/tasks/task_e_68941d8e2b34832ead5f62f5cb5aac44