### PR TITLE
Fragebogen zur Bell-Score-Berechnung

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,38 @@ WordPress-Plugin zum täglichen Erfassen von Bell-Score, emotionalem Zustand, Sy
 - **Tabellenbereinigung:** Unter *Einstellungen → MECFS Tracker* kann festgelegt werden, ob die Datenbanktabellen bei Deaktivierung des Plugins gelöscht werden (`mecfs_tracker_cleanup`).
 
 ## Bell-Score und emotionaler Zustand
-Der Bell-Score beschreibt die allgemeine Belastbarkeit auf einer Skala von 0–100. Für diese erste Version erfolgt die Eingabe manuell über einen Schieberegler.
+Der Bell-Score beschreibt die allgemeine Belastbarkeit auf einer Skala von 0–100. Im Formular wird er über einen kurzen Fragebogen ermittelt. 
 
-Der emotionale Zustand wird ebenfalls über einen Schieberegler von 0–100 erfasst. Eine detaillierte Berechnungsgrundlage kann in späteren Versionen durch Fragebögen ergänzt werden.
+Der emotionale Zustand wird weiterhin über einen Schieberegler von 0–100 erfasst.
+
+### Berechnungsgrundlage
+Der Fragebogen besteht aus vier Fragen. Jede Antwort hat einen fest zugewiesenen Punktwert:
+
+1. **Liegezeit (außer Schlaf)**  
+   Fast den ganzen Tag (22–24 h) → 0 Punkte  
+   Mehr als 18 Stunden → 10 Punkte  
+   Zwischen 12 und 18 Stunden → 20 Punkte  
+   Weniger als 12 Stunden → 30 Punkte
+2. **Anstrengendste körperliche Aktivität**  
+   Nur Toilette/Zähneputzen o. ä. → 0 Punkte  
+   Körperpflege & Anziehen → 20 Punkte  
+   Kleine Mahlzeit zubereiten, 1–2 kurze Wege in der Wohnung → 30 Punkte  
+   Spaziergang, Haushalt, Einkauf oder > 30 Min aufrecht → 40 Punkte
+3. **Symptomverschlechterung nach Aktivität (PEM)**  
+   Stark – bereits nach kleinster Aktivität → 0 Punkte  
+   Deutlich – auch bei einfacher Aktivität → 20 Punkte  
+   Leicht – nach moderater Aktivität → 30 Punkte  
+   Keine spürbare Verschlechterung → 40 Punkte
+4. **Maximale Konzentrationsdauer**  
+   Unter 5 Minuten → 10 Punkte  
+   5–15 Minuten → 20 Punkte  
+   15–30 Minuten → 30 Punkte  
+   Über 30 Minuten → 40 Punkte
+
+Auswertung:
+
+1. Punkte aller Antworten addieren
+2. Summe durch 4 teilen
+3. Ergebnis auf den nächsten 10er-Wert runden
+
+Das Resultat ist der tagesaktuelle Mini-Bell-Score (0–100 in 10er-Schritten).

--- a/assets/form.css
+++ b/assets/form.css
@@ -3,3 +3,10 @@
     flex-direction: column;
     gap: 1rem;
 }
+.bell-question {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+}
+.bell-question label {
+    margin-right: 0.5rem;
+}

--- a/assets/form.js
+++ b/assets/form.js
@@ -1,6 +1,19 @@
 jQuery(function ($) {
     $('#mecfs-tracker-form').on('submit', function (e) {
         e.preventDefault();
+        let sum = 0;
+        const questions = 4;
+        for (let i = 1; i <= questions; i++) {
+            const val = parseInt($('input[name="bell_q' + i + '"]:checked').val(), 10);
+            if (isNaN(val)) {
+                alert('Bitte alle Fragen beantworten.');
+                return;
+            }
+            sum += val;
+        }
+        const avg = sum / questions;
+        const bell = Math.round(avg / 10) * 10;
+        $('input[name="bell_score"]').val(bell);
         const data = $(this).serialize();
         $.post(MECFSTracker.ajax, data + '&action=mecfs_save_entry&nonce=' + MECFSTracker.nonce)
             .done(() => alert('Gespeichert'))

--- a/includes/class-frontend-form.php
+++ b/includes/class-frontend-form.php
@@ -27,8 +27,57 @@ class Frontend_Form {
         ?>
         <form id="mecfs-tracker-form">
             <input type="date" name="entry_date" value="<?php echo esc_attr( current_time( 'Y-m-d' ) ); ?>" />
-            <label><?php esc_html_e( 'Bell-Score', 'mecfs-tracker' ); ?></label>
-            <input type="range" name="bell_score" min="0" max="100" />
+            <?php
+            $questions = [
+                [
+                    'text'    => __( 'Wie viel Zeit hast du heute insgesamt im Liegen verbracht?', 'mecfs-tracker' ),
+                    'options' => [
+                        0  => __( 'Fast den ganzen Tag (22–24 h)', 'mecfs-tracker' ),
+                        10 => __( 'Mehr als 18 Stunden', 'mecfs-tracker' ),
+                        20 => __( 'Zwischen 12 und 18 Stunden', 'mecfs-tracker' ),
+                        30 => __( 'Weniger als 12 Stunden', 'mecfs-tracker' ),
+                    ],
+                ],
+                [
+                    'text'    => __( 'Was war heute deine körperlich anspruchsvollste Aktivität?', 'mecfs-tracker' ),
+                    'options' => [
+                        0  => __( 'Nur Toilette / Zähneputzen o. ä.', 'mecfs-tracker' ),
+                        20 => __( 'Körperpflege & Anziehen', 'mecfs-tracker' ),
+                        30 => __( 'Kleine Mahlzeit zubereiten, 1–2 kurze Wege in der Wohnung', 'mecfs-tracker' ),
+                        40 => __( 'Spaziergang, Haushalt, Einkauf oder > 30 Min aufrecht', 'mecfs-tracker' ),
+                    ],
+                ],
+                [
+                    'text'    => __( 'Wie stark haben sich heute deine Symptome nach körperlicher oder geistiger Aktivität verschlechtert?', 'mecfs-tracker' ),
+                    'options' => [
+                        0  => __( 'Stark – bereits nach kleinster Aktivität', 'mecfs-tracker' ),
+                        20 => __( 'Deutlich – auch bei einfacher Aktivität', 'mecfs-tracker' ),
+                        30 => __( 'Leicht – nach moderater Aktivität', 'mecfs-tracker' ),
+                        40 => __( 'Keine spürbare Verschlechterung', 'mecfs-tracker' ),
+                    ],
+                ],
+                [
+                    'text'    => __( 'Wie lange konntest du dich heute am Stück geistig konzentrieren (z. B. lesen, zuhören, schreiben)?', 'mecfs-tracker' ),
+                    'options' => [
+                        10 => __( 'Unter 5 Minuten', 'mecfs-tracker' ),
+                        20 => __( '5–15 Minuten', 'mecfs-tracker' ),
+                        30 => __( '15–30 Minuten', 'mecfs-tracker' ),
+                        40 => __( 'Über 30 Minuten', 'mecfs-tracker' ),
+                    ],
+                ],
+            ];
+            foreach ( $questions as $index => $question ) :
+                ?>
+                <fieldset class="bell-question">
+                    <legend><?php echo esc_html( $question['text'] ); ?></legend>
+                    <?php foreach ( $question['options'] as $value => $label ) : ?>
+                        <label><input type="radio" name="bell_q<?php echo $index + 1; ?>" value="<?php echo esc_attr( $value ); ?>" required /><?php echo esc_html( $label ); ?></label>
+                    <?php endforeach; ?>
+                </fieldset>
+                <?php
+            endforeach;
+            ?>
+            <input type="hidden" name="bell_score" value="0" />
             <label><?php esc_html_e( 'Emotionaler Zustand', 'mecfs-tracker' ); ?></label>
             <input type="range" name="emotion" min="0" max="100" />
             <!-- TODO: Dynamische Symptome -->


### PR DESCRIPTION
## Summary
- Fragebogen auf vier objektive Fragen reduziert und um detaillierte Antwortoptionen mit Punktwerten ergänzt
- JavaScript berechnet den Mini-Bell-Score durch Mittelwertbildung und Rundung auf den nächsten 10er-Wert
- README erläutert nun die vier Fragen sowie die Berechnungslogik des Mini-Bell-Scores

## Testing
- `php -l includes/class-frontend-form.php`
- `node --check assets/form.js`


------
https://chatgpt.com/codex/tasks/task_e_68941d8e2b34832ead5f62f5cb5aac44