### PR TITLE
Fix autoloader to properly load plugin classes

### DIFF
--- a/includes/autoloader.php
+++ b/includes/autoloader.php
@@ -1,10 +1,18 @@
 <?php
 spl_autoload_register(
     function ( $class ) {
-        if ( strpos( $class, 'MECFSTracker\\' ) !== 0 ) {
+        $prefix = 'MECFSTracker\\';
+
+        if ( strpos( $class, $prefix ) !== 0 ) {
             return;
         }
-        $path = __DIR__ . '/' . strtolower( str_replace( '\\', '/', substr( $class, 14 ) ) ) . '.php';
+
+        $relative_class = substr( $class, strlen( $prefix ) );
+        $relative_class = str_replace( '_', '-', $relative_class );
+        $relative_class = strtolower( str_replace( '\\', '/', $relative_class ) );
+
+        $path = __DIR__ . '/class-' . $relative_class . '.php';
+
         if ( file_exists( $path ) ) {
             require $path;
         }


### PR DESCRIPTION
## Summary
- improve autoloader to map MECFSTracker classes to `class-*.php`

## Testing
- `php -l includes/autoloader.php`
- `php -l mecfs-tracker.php`


------
https://chatgpt.com/codex/tasks/task_e_689431fcdaa4832ea440d87b76490e94