### PR TITLE
Fix release workflow to create plugin zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,14 @@ jobs:
       - name: Install zip utility
         run: sudo apt-get update && sudo apt-get install -y zip
 
-      - name: Create release directory
-        run: mkdir -p release
+      - name: Prepare plugin folder
+        run: |
+          mkdir -p release/mecfs-tracker
+          rsync -av --exclude='.git*' --exclude='release' --exclude='.github' ./ release/mecfs-tracker/
 
       - name: Package plugin
-        run: |
-          zip -r release/mecfs-tracker.zip . \
-            -x '*.git*' 'release/*' '.github/*'
+        working-directory: release
+        run: zip -r mecfs-tracker.zip mecfs-tracker
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- update release workflow to build WordPress plugin ZIP

## Testing
- `php -l mecfs-tracker.php`
- `php -l includes/class-plugin.php`
- `php -l includes/class-database.php`
- `php -l includes/class-frontend-form.php`
- `php -l includes/class-rest-api.php`
- `php -l includes/autoloader.php`
- `php -l includes/class-admin-settings.php`
- `php -l includes/class-exporter.php`


------
https://chatgpt.com/codex/tasks/task_e_689433956c18832e847de7c54689a134