### PR TITLE
Replace shortcodes with Gutenberg blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 WordPress-Plugin zum täglichen Erfassen von Bell-Score, emotionalem Zustand, Symptomen und Notizen.
 
 ## Features
-- Frontend-Formular mit Shortcode `[mecfs_tracker_form]` für Tagesprotokolle
+- Frontend-Formular als Gutenberg-Block für Tagesprotokolle
 - Speicherung der Daten in eigenen Datenbanktabellen
-- Gutenberg-Blöcke für Formular und Diagramm
-- Export der eigenen Einträge als CSV über `[mecfs_export_button]`
+- Gutenberg-Blöcke für Formular, Diagramm und Export-Button
+- Export der eigenen Einträge als CSV über den Export-Block
 - REST-API-Endpunkt `/wp-json/mecfs/v1/entries` für Diagramme und externe Abfragen
 
 ## Konfiguration

--- a/blocks/export/block.json
+++ b/blocks/export/block.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": 2,
+  "name": "mecfs/export",
+  "title": "MECFS Export-Button",
+  "category": "widgets",
+  "icon": "download",
+  "editorScript": "file:./index.js",
+  "render": "mecfs_tracker_render_export_block"
+}

--- a/blocks/export/index.js
+++ b/blocks/export/index.js
@@ -1,0 +1,10 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function Edit() {
+    return (
+        <div {...useBlockProps()}>
+            <p>{__('Export-Button wird im Frontend gerendert.', 'mecfs-tracker')}</p>
+        </div>
+    );
+}

--- a/includes/class-exporter.php
+++ b/includes/class-exporter.php
@@ -5,7 +5,6 @@ class Exporter {
 
     public function register() {
         add_action( 'wp_ajax_mecfs_export', [ $this, 'export_csv' ] );
-        add_shortcode( 'mecfs_export_button', [ $this, 'button' ] );
     }
 
     public function button() {

--- a/includes/class-frontend-form.php
+++ b/includes/class-frontend-form.php
@@ -5,7 +5,6 @@ class Frontend_Form {
 
     public function register() {
         add_action( 'wp_enqueue_scripts', [ $this, 'assets' ] );
-        add_shortcode( 'mecfs_tracker_form', [ $this, 'render' ] );
         add_action( 'wp_ajax_mecfs_save_entry', [ $this, 'save_entry' ] );
         add_action( 'wp_ajax_nopriv_mecfs_save_entry', '__return_false' );
     }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -14,5 +14,6 @@ class Plugin {
     public function register_blocks() {
         register_block_type( __DIR__ . '/../blocks/form' );
         register_block_type( __DIR__ . '/../blocks/chart' );
+        register_block_type( __DIR__ . '/../blocks/export' );
     }
 }

--- a/mecfs-tracker.php
+++ b/mecfs-tracker.php
@@ -21,5 +21,11 @@ register_activation_hook( __FILE__, [ '\\MECFSTracker\\Database', 'activate' ] )
 register_deactivation_hook( __FILE__, [ '\\MECFSTracker\\Database', 'maybe_cleanup' ] );
 
 function mecfs_tracker_render_form_block() {
-    return do_shortcode( '[mecfs_tracker_form]' );
+    $form = new \MECFSTracker\Frontend_Form();
+    return $form->render();
+}
+
+function mecfs_tracker_render_export_block() {
+    $exporter = new \MECFSTracker\Exporter();
+    return $exporter->button();
 }


### PR DESCRIPTION
## Summary
- remove shortcode hooks from frontend form and exporter
- add export button Gutenberg block and render form/export without shortcodes
- update documentation to reference blocks only

## Testing
- `php -l mecfs-tracker.php includes/class-frontend-form.php includes/class-exporter.php includes/class-plugin.php`
- `node --check blocks/export/index.js && echo 'export ok'`
- `node --check blocks/form/index.js && echo 'form ok'`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68943785bcd0832ea9429f30cd24d9cf