### PR TITLE
Guard plugin functions against redeclaration

### DIFF
--- a/mecfs-tracker.php
+++ b/mecfs-tracker.php
@@ -11,21 +11,27 @@ defined( 'ABSPATH' ) || exit;
 
 require_once __DIR__ . '/includes/autoloader.php';
 
-function mecfs_tracker_run() {
-    $plugin = new \MECFSTracker\Plugin();
-    $plugin->run();
+if ( ! function_exists( 'mecfs_tracker_run' ) ) {
+    function mecfs_tracker_run() {
+        $plugin = new \MECFSTracker\Plugin();
+        $plugin->run();
+    }
 }
 mecfs_tracker_run();
 
 register_activation_hook( __FILE__, [ '\\MECFSTracker\\Database', 'activate' ] );
 register_deactivation_hook( __FILE__, [ '\\MECFSTracker\\Database', 'maybe_cleanup' ] );
 
-function mecfs_tracker_render_form_block() {
-    $form = new \MECFSTracker\Frontend_Form();
-    return $form->render();
+if ( ! function_exists( 'mecfs_tracker_render_form_block' ) ) {
+    function mecfs_tracker_render_form_block() {
+        $form = new \MECFSTracker\Frontend_Form();
+        return $form->render();
+    }
 }
 
-function mecfs_tracker_render_export_block() {
-    $exporter = new \MECFSTracker\Exporter();
-    return $exporter->button();
+if ( ! function_exists( 'mecfs_tracker_render_export_block' ) ) {
+    function mecfs_tracker_render_export_block() {
+        $exporter = new \MECFSTracker\Exporter();
+        return $exporter->button();
+    }
 }


### PR DESCRIPTION
## Summary
- prevent fatal errors when multiple versions of the plugin are loaded by guarding global helper functions with `function_exists`

## Testing
- `php -l mecfs-tracker.php`


------
https://chatgpt.com/codex/tasks/task_e_6894395f5f94832ea32f1ddf82e752a0