### PR TITLE
Add GitHub auto-updates and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,25 +2,26 @@
 name: Build Release
 
 'on':
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - main
 
 permissions:
   contents: write
-  actions: write
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Get version
+        id: get_version
+        run: |
+          VERSION=$(grep -E '^ \* Version:' mecfs-tracker.php \
+            | awk '{print $3}')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Install zip utility
         run: sudo apt-get update && sudo apt-get install -y zip
@@ -38,12 +39,11 @@ jobs:
         working-directory: release
         run: zip -r mecfs-tracker.zip mecfs-tracker
 
-      - name: Create pre-release
+      - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: prerelease-${{ github.run_number }}
-          name: "Pre-release ${{ github.run_number }}"
-          prerelease: true
+          tag_name: v${{ steps.get_version.outputs.version }}
+          name: "Release ${{ steps.get_version.outputs.version }}"
           files: release/mecfs-tracker.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/includes/class-github-updater.php
+++ b/includes/class-github-updater.php
@@ -1,0 +1,64 @@
+<?php
+namespace MECFSTracker;
+
+class GitHub_Updater {
+    private $owner = 'OWNER'; // TODO: Replace with actual GitHub username/organization
+    private $repo = 'mecfs-tracker';
+
+    public function register() {
+        add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_for_update' ] );
+    }
+
+    public function check_for_update( $transient ) {
+        if ( empty( $transient->checked ) ) {
+            return $transient;
+        }
+
+        $plugin = plugin_basename( MECFS_TRACKER_PLUGIN_FILE );
+
+        if ( ! isset( $transient->checked[ $plugin ] ) ) {
+            return $transient;
+        }
+
+        $current_version = $transient->checked[ $plugin ];
+
+        $response = wp_remote_get( sprintf( 'https://api.github.com/repos/%s/%s/releases/latest', $this->owner, $this->repo ) );
+        if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+            return $transient;
+        }
+
+        $release = json_decode( wp_remote_retrieve_body( $response ) );
+        if ( ! $release || empty( $release->tag_name ) ) {
+            return $transient;
+        }
+
+        $remote_version = ltrim( $release->tag_name, 'v' );
+        if ( version_compare( $remote_version, $current_version, '<=' ) ) {
+            return $transient;
+        }
+
+        $package = '';
+        if ( ! empty( $release->assets ) ) {
+            foreach ( $release->assets as $asset ) {
+                if ( $asset->name === $this->repo . '.zip' ) {
+                    $package = $asset->browser_download_url;
+                    break;
+                }
+            }
+        }
+
+        if ( empty( $package ) ) {
+            $package = $release->zipball_url;
+        }
+
+        $transient->response[ $plugin ] = (object) [
+            'slug'        => $this->repo,
+            'plugin'      => $plugin,
+            'new_version' => $remote_version,
+            'package'     => $package,
+            'url'         => $release->html_url,
+        ];
+
+        return $transient;
+    }
+}

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -4,6 +4,7 @@ namespace MECFSTracker;
 class Plugin {
 
     public function run() {
+        ( new GitHub_Updater() )->register();
         ( new Admin_Settings() )->register();
         ( new Frontend_Form() )->register();
         ( new Exporter() )->register();

--- a/mecfs-tracker.php
+++ b/mecfs-tracker.php
@@ -5,9 +5,13 @@
  * Version:     0.1.0
  * Author:      Ihr Name
  * Text Domain: mecfs-tracker
+ * Update URI:  https://github.com/OWNER/mecfs-tracker
  */
 
 defined( 'ABSPATH' ) || exit;
+
+define( 'MECFS_TRACKER_VERSION', '0.1.0' );
+define( 'MECFS_TRACKER_PLUGIN_FILE', __FILE__ );
 
 require_once __DIR__ . '/includes/autoloader.php';
 


### PR DESCRIPTION
## Summary
- check GitHub releases on `pre_set_site_transient_update_plugins` to enable automatic updates
- add GitHub Actions workflow to package plugin and publish release on push to `main`

## Testing
- `php -l mecfs-tracker.php`
- `php -l includes/class-github-updater.php`
- `php -l includes/class-plugin.php`
- `yamllint .github/workflows/release.yml && echo 'YAML OK'`


------
https://chatgpt.com/codex/tasks/task_e_68943b4e7934832ebe5c6a4d04e4b7b7