### PR TITLE
Enable Gutenberg blocks and automate version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,20 +19,24 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      - name: Get version
-        id: get_version
+      - name: Bump version
+        id: bump_version
         run: |
-          VERSION=$(grep -E '^ \* Version:' mecfs-tracker.php \
-            | awk '{print $3}')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Extract version
-        id: plugin_version
-        run: |
-          VERSION=$(grep -E '^ \* Version:' mecfs-tracker.php \
-            | awk '{print $3}')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          CURRENT=$(grep -E '^ \* Version:' mecfs-tracker.php | awk '{print $3}')
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          PATCH=$((PATCH+1))
+          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+          sed -i "s/^ \* Version:.*/ * Version:     $NEW_VERSION/" mecfs-tracker.php
+          sed -i "s/define( 'MECFS_TRACKER_VERSION', '.*' );/define( 'MECFS_TRACKER_VERSION', '$NEW_VERSION' );/" mecfs-tracker.php
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@github.com'
+          git commit -am "chore: bump version to $NEW_VERSION"
+          git tag v$NEW_VERSION
+          git push origin HEAD:main --tags
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Install zip utility
         run: sudo apt-get update && sudo apt-get install -y zip
@@ -53,9 +57,8 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v${{ steps.plugin_version.outputs.version }}
-          name: "Release ${{ steps.plugin_version.outputs.version }}"
-
+          tag_name: v${{ steps.bump_version.outputs.version }}
+          name: "Release ${{ steps.bump_version.outputs.version }}"
           files: release/mecfs-tracker.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/blocks/chart/index.asset.php
+++ b/blocks/chart/index.asset.php
@@ -1,1 +1,5 @@
-<?php return array('dependencies' => array('react-jsx-runtime', 'wp-block-editor', 'wp-i18n'), 'version' => '61462f10276b78717e75');
+<?php
+return array(
+    'dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n'),
+    'version' => '0.1.1',
+);

--- a/blocks/chart/index.js
+++ b/blocks/chart/index.js
@@ -1,1 +1,17 @@
-(()=>{"use strict";window.wp.i18n,window.wp.blockEditor,window.ReactJSXRuntime})();
+( function( blocks, element, i18n ) {
+    const { registerBlockType } = blocks;
+    const { createElement } = element;
+    const { __ } = i18n;
+
+    registerBlockType( 'mecfs/chart', {
+        title: __( 'MECFS Tracker Diagramm', 'mecfs-tracker' ),
+        icon: 'chart-bar',
+        category: 'widgets',
+        edit: function() {
+            return createElement( 'p', {}, __( 'MECFS Tracker Diagramm', 'mecfs-tracker' ) );
+        },
+        save: function() {
+            return null;
+        }
+    } );
+} )( window.wp.blocks, window.wp.element, window.wp.i18n );

--- a/blocks/export/index.asset.php
+++ b/blocks/export/index.asset.php
@@ -1,1 +1,5 @@
-<?php return array('dependencies' => array('react-jsx-runtime', 'wp-block-editor', 'wp-i18n'), 'version' => '61462f10276b78717e75');
+<?php
+return array(
+    'dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n'),
+    'version' => '0.1.1',
+);

--- a/blocks/export/index.js
+++ b/blocks/export/index.js
@@ -1,1 +1,17 @@
-(()=>{"use strict";window.wp.i18n,window.wp.blockEditor,window.ReactJSXRuntime})();
+( function( blocks, element, i18n ) {
+    const { registerBlockType } = blocks;
+    const { createElement } = element;
+    const { __ } = i18n;
+
+    registerBlockType( 'mecfs/export', {
+        title: __( 'MECFS Export-Button', 'mecfs-tracker' ),
+        icon: 'download',
+        category: 'widgets',
+        edit: function() {
+            return createElement( 'p', {}, __( 'MECFS Export-Button', 'mecfs-tracker' ) );
+        },
+        save: function() {
+            return null;
+        }
+    } );
+} )( window.wp.blocks, window.wp.element, window.wp.i18n );

--- a/blocks/form/index.asset.php
+++ b/blocks/form/index.asset.php
@@ -1,1 +1,5 @@
-<?php return array('dependencies' => array('react-jsx-runtime', 'wp-block-editor', 'wp-i18n'), 'version' => '61462f10276b78717e75');
+<?php
+return array(
+    'dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n'),
+    'version' => '0.1.1',
+);

--- a/blocks/form/index.js
+++ b/blocks/form/index.js
@@ -1,1 +1,17 @@
-(()=>{"use strict";window.wp.i18n,window.wp.blockEditor,window.ReactJSXRuntime})();
+( function( blocks, element, i18n ) {
+    const { registerBlockType } = blocks;
+    const { createElement } = element;
+    const { __ } = i18n;
+
+    registerBlockType( 'mecfs/form', {
+        title: __( 'MECFS Tracker Formular', 'mecfs-tracker' ),
+        icon: 'clipboard',
+        category: 'widgets',
+        edit: function() {
+            return createElement( 'p', {}, __( 'MECFS Tracker Formular', 'mecfs-tracker' ) );
+        },
+        save: function() {
+            return null;
+        }
+    } );
+} )( window.wp.blocks, window.wp.element, window.wp.i18n );

--- a/mecfs-tracker.php
+++ b/mecfs-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: MECFS Tracker
  * Description: Tagesprotokoll für Bell-Score, Emotionen, Symptome und Notizen.
- * Version:     0.1.0
+ * Version:     0.1.1
  * Author:      Ihr Name
  * Text Domain: mecfs-tracker
  * Update URI:  https://github.com/OWNER/mecfs-tracker
@@ -10,7 +10,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'MECFS_TRACKER_VERSION', '0.1.0' );
+define( 'MECFS_TRACKER_VERSION', '0.1.1' );
 define( 'MECFS_TRACKER_PLUGIN_FILE', __FILE__ );
 
 require_once __DIR__ . '/includes/autoloader.php';


### PR DESCRIPTION
## Summary
- register plugin blocks via JavaScript so they appear on pages, posts and widgets
- bump plugin version to 0.1.1 and auto-increment version in release workflow

## Testing
- `php -l mecfs-tracker.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68944938ab38832ebb9da39454b7d93c