### PR TITLE
fix: build block assets for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
           git push origin HEAD:main --tags
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Install dependencies and build assets
+        run: |
+          npm ci
+          npm run build
+
       - name: Install zip utility
         run: sudo apt-get update && sudo apt-get install -y zip
 
@@ -48,6 +53,9 @@ jobs:
             --exclude='.git*' \
             --exclude='release' \
             --exclude='.github' \
+            --exclude='node_modules' \
+            --exclude='package-lock.json' \
+            --exclude='package.json' \
             ./ release/mecfs-tracker/
 
       - name: Package plugin

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "wp-scripts build blocks/**/index.js"
+    "build": "wp-scripts build blocks/form/index.js --output-path=build/form && cp build/form/index.js blocks/form/index.js && cp build/form/index.asset.php blocks/form/index.asset.php && wp-scripts build blocks/export/index.js --output-path=build/export && cp build/export/index.js blocks/export/index.js && cp build/export/index.asset.php blocks/export/index.asset.php && wp-scripts build blocks/chart/index.js --output-path=build/chart && cp build/chart/index.js blocks/chart/index.js && cp build/chart/index.asset.php blocks/chart/index.asset.php && rm -rf build"
   },
   "devDependencies": {
     "@wordpress/scripts": "^30.0.0"


### PR DESCRIPTION
## Summary
- build block scripts and asset metadata in each block folder
- compile assets during release workflow and exclude development files from zip

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68944c7e0824832e810b4b39f0858732