### PR TITLE
Add server render templates for dynamic Gutenberg blocks

### DIFF
--- a/blocks/chart/block.json
+++ b/blocks/chart/block.json
@@ -4,5 +4,6 @@
   "title": "MECFS Tracker Diagramm",
   "category": "widgets",
   "icon": "chart-bar",
-  "editorScript": "file:./index.js"
+  "editorScript": "file:./index.js",
+  "render": "file:./render.php"
 }

--- a/blocks/chart/render.php
+++ b/blocks/chart/render.php
@@ -1,0 +1,2 @@
+<?php
+echo '<div id="mecfs-tracker-chart"></div>';

--- a/blocks/export/block.json
+++ b/blocks/export/block.json
@@ -5,5 +5,5 @@
   "category": "widgets",
   "icon": "download",
   "editorScript": "file:./index.js",
-  "render": "mecfs_tracker_render_export_block"
+  "render": "file:./render.php"
 }

--- a/blocks/export/render.php
+++ b/blocks/export/render.php
@@ -1,0 +1,3 @@
+<?php
+$exporter = new \MECFSTracker\Exporter();
+echo $exporter->button();

--- a/blocks/form/block.json
+++ b/blocks/form/block.json
@@ -5,5 +5,5 @@
   "category": "widgets",
   "icon": "clipboard",
   "editorScript": "file:./index.js",
-  "render": "mecfs_tracker_render_form_block"
+  "render": "file:./render.php"
 }

--- a/blocks/form/render.php
+++ b/blocks/form/render.php
@@ -1,0 +1,3 @@
+<?php
+$form = new \MECFSTracker\Frontend_Form();
+echo $form->render();

--- a/mecfs-tracker.php
+++ b/mecfs-tracker.php
@@ -25,17 +25,3 @@ mecfs_tracker_run();
 
 register_activation_hook( __FILE__, [ '\\MECFSTracker\\Database', 'activate' ] );
 register_deactivation_hook( __FILE__, [ '\\MECFSTracker\\Database', 'maybe_cleanup' ] );
-
-if ( ! function_exists( 'mecfs_tracker_render_form_block' ) ) {
-    function mecfs_tracker_render_form_block() {
-        $form = new \MECFSTracker\Frontend_Form();
-        return $form->render();
-    }
-}
-
-if ( ! function_exists( 'mecfs_tracker_render_export_block' ) ) {
-    function mecfs_tracker_render_export_block() {
-        $exporter = new \MECFSTracker\Exporter();
-        return $exporter->button();
-    }
-}


### PR DESCRIPTION
## Summary
- delegate block rendering to PHP templates
- remove unused block render helpers

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `php -l mecfs-tracker.php blocks/form/render.php blocks/export/render.php blocks/chart/render.php`


------
https://chatgpt.com/codex/tasks/task_e_6894896610f4832eb47db126864b62c0