### PR TITLE
Add custom symptom inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MECFS Tracker
 
-WordPress-Plugin zum täglichen Erfassen von Bell-Score, emotionalem Zustand, Symptomen und Notizen.
+WordPress-Plugin zum täglichen Erfassen von Bell-Score, emotionalem Zustand, individuellen Symptomen und Notizen.
 
 ## Features
 - Frontend-Formular als Gutenberg-Block für Tagesprotokolle
@@ -8,6 +8,7 @@ WordPress-Plugin zum täglichen Erfassen von Bell-Score, emotionalem Zustand, Sy
 - Gutenberg-Blöcke für Formular, Diagramm und Export-Button
 - Export der eigenen Einträge als CSV über den Export-Block
 - REST-API-Endpunkt `/wp-json/mecfs/v1/entries` für Diagramme und externe Abfragen
+- Individuelle Symptome mit Schweregrad erfassen
 
 ## Konfiguration
 - **Tabellenbereinigung:** Unter *Einstellungen → MECFS Tracker* kann festgelegt werden, ob die Datenbanktabellen bei Deaktivierung des Plugins gelöscht werden (`mecfs_tracker_cleanup`).

--- a/assets/form.js
+++ b/assets/form.js
@@ -1,4 +1,9 @@
 jQuery(function ($) {
+    let symptomIndex = 0;
+    $('#add-symptom').on('click', function () {
+        $('#custom-symptoms').append('<div class="symptom-field"><input type="text" name="new_symptoms[' + symptomIndex + '][label]" placeholder="Symptom" /> <input type="range" name="new_symptoms[' + symptomIndex + '][severity]" min="0" max="100" /></div>');
+        symptomIndex++;
+    });
     $('#mecfs-tracker-form').on('submit', function (e) {
         e.preventDefault();
         let sum = 0;

--- a/includes/class-database.php
+++ b/includes/class-database.php
@@ -49,6 +49,24 @@ class Database {
         ) $charset;";
 
         dbDelta( $sql );
+
+        self::seed_symptoms();
+    }
+
+    private static function seed_symptoms() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'mecfs_symptoms';
+        $defaults = [
+            [ 'slug' => 'fatigue', 'label' => 'Fatigue' ],
+            [ 'slug' => 'pain', 'label' => 'Schmerzen' ],
+            [ 'slug' => 'brain-fog', 'label' => 'Brain Fog' ],
+        ];
+        foreach ( $defaults as $symptom ) {
+            $exists = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM $table WHERE slug = %s", $symptom['slug'] ) );
+            if ( ! $exists ) {
+                $wpdb->insert( $table, $symptom );
+            }
+        }
     }
 
     public static function maybe_cleanup() {


### PR DESCRIPTION
## Summary
- allow users to record predefined and custom symptoms with severity
- seed default symptom list on activation
- document individual symptom tracking

## Testing
- `php -l includes/class-database.php`
- `php -l includes/class-frontend-form.php`
- `node --check assets/form.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894b60b7920832ea52313af2b4529f0