### PR TITLE
Fix Symptom hinzufügen button not working

### DIFF
--- a/includes/class-frontend-form.php
+++ b/includes/class-frontend-form.php
@@ -10,7 +10,13 @@ class Frontend_Form {
     }
 
     public function assets() {
-        wp_enqueue_script( 'mecfs-tracker', plugins_url( 'assets/form.js', dirname( __FILE__ ) ), [ 'jquery' ], '0.1.0', true );
+        wp_enqueue_script(
+            'mecfs-tracker',
+            plugins_url( 'assets/form.js', MECFS_TRACKER_PLUGIN_FILE ),
+            [ 'jquery' ],
+            MECFS_TRACKER_VERSION,
+            true
+        );
         wp_localize_script( 'mecfs-tracker', 'MECFSTracker', [
             'ajax'  => admin_url( 'admin-ajax.php' ),
             'nonce' => wp_create_nonce( 'mecfs_entry' ),


### PR DESCRIPTION
## Summary
- Ensure frontend script uses correct plugin path so that "Symptom hinzufügen" button works

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894be58c098832e949e711f337bba77