### PR TITLE
Add emotional state questionnaire and tabular symptom sliders

### DIFF
--- a/assets/form.js
+++ b/assets/form.js
@@ -1,9 +1,25 @@
 jQuery(function ($) {
+    function addRangeListeners(context) {
+        $('input[type="range"]', context).each(function () {
+            const $range = $(this);
+            const $value = $range.next('.range-value');
+            $value.text($range.val());
+            $range.on('input', function () {
+                $value.text($range.val());
+            });
+        });
+    }
+
+    addRangeListeners(document);
+
     let symptomIndex = 0;
     $('#add-symptom').on('click', function () {
-        $('#custom-symptoms').append('<div class="symptom-field"><input type="text" name="new_symptoms[' + symptomIndex + '][label]" placeholder="Symptom" /> <input type="range" name="new_symptoms[' + symptomIndex + '][severity]" min="0" max="100" /></div>');
+        const row = $('<tr class="symptom-field"><td><input type="text" name="new_symptoms[' + symptomIndex + '][label]" placeholder="Symptom" /></td><td><input type="range" name="new_symptoms[' + symptomIndex + '][severity]" min="0" max="100" value="0" /><span class="range-value">0</span><div class="slider-scale"><span>0</span><span>100</span></div></td></tr>');
+        $('#symptom-table-body').append(row);
+        addRangeListeners(row);
         symptomIndex++;
     });
+
     $('#mecfs-tracker-form').on('submit', function (e) {
         e.preventDefault();
         let sum = 0;
@@ -20,6 +36,31 @@ jQuery(function ($) {
         const max = 100;
         const bell = Math.round((sum / total) * max);
         $('input[name="bell_score"]').val(bell);
+
+        const emotionQuestions = [
+            { id: 'aengste', invert: true },
+            { id: 'stimmung', invert: false },
+            { id: 'antrieb', invert: false },
+            { id: 'depressivität', invert: true }
+        ];
+        let emotionSum = 0;
+        let invertCount = 0;
+        let nonInvertCount = 0;
+        emotionQuestions.forEach(q => {
+            let val = parseInt($('input[name="emotion[' + q.id + ']"]').val(), 10);
+            if (q.invert) {
+                val = 10 - val;
+                invertCount++;
+            } else {
+                nonInvertCount++;
+            }
+            emotionSum += val;
+        });
+        const minSum = nonInvertCount * 1;
+        const maxSum = invertCount * 9 + nonInvertCount * 10;
+        const emotion = Math.round(((emotionSum - minSum) / (maxSum - minSum)) * 100);
+        $('input[name="emotion"]').val(emotion);
+
         const data = $(this).serialize();
         $.post(MECFSTracker.ajax, data + '&action=mecfs_save_entry&nonce=' + MECFSTracker.nonce)
             .done(() => alert('Gespeichert'))

--- a/assets/mecfs-tracker.css
+++ b/assets/mecfs-tracker.css
@@ -11,6 +11,35 @@
     display: block;
     margin-bottom: 0.25rem;
 }
+#emotion-questions {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+.emotion-question {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+}
+.emotion-question label {
+    display: block;
+    margin-bottom: 0.25rem;
+}
+.symptom-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.symptom-table td {
+    padding: 0.25rem;
+    vertical-align: middle;
+}
+.slider-scale {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+}
+.range-value {
+    margin-left: 0.5rem;
+}
 #mecfs-tracker-chart {
     max-width: 100%;
     margin-top: 1rem;

--- a/includes/class-frontend-form.php
+++ b/includes/class-frontend-form.php
@@ -85,17 +85,65 @@ class Frontend_Form {
             endforeach;
             ?>
             <input type="hidden" name="bell_score" value="0" />
-            <label><?php esc_html_e( 'Emotionaler Zustand', 'mecfs-tracker' ); ?></label>
-            <input type="range" name="emotion" min="0" max="100" />
+            <div id="emotion-questions">
+                <h4><?php esc_html_e( 'Emotionaler Zustand', 'mecfs-tracker' ); ?></h4>
+                <?php
+                $emotion_questions = [
+                    [
+                        'id'     => 'aengste',
+                        'text'   => __( 'Wie stark fühlst Du Dich heute von Ängsten oder Sorgen belastet?', 'mecfs-tracker' ),
+                        'scale'  => __( '1 = überhaupt nicht, 10 = sehr stark', 'mecfs-tracker' ),
+                        'invert' => true,
+                    ],
+                    [
+                        'id'     => 'stimmung',
+                        'text'   => __( 'Wie ist Deine allgemeine Stimmung heute?', 'mecfs-tracker' ),
+                        'scale'  => __( '1 = sehr schlecht, 10 = sehr gut', 'mecfs-tracker' ),
+                        'invert' => false,
+                    ],
+                    [
+                        'id'     => 'antrieb',
+                        'text'   => __( 'Wie stark ist Dein innerer Antrieb heute?', 'mecfs-tracker' ),
+                        'scale'  => __( '1 = keinerlei Antrieb, 10 = sehr starker Antrieb', 'mecfs-tracker' ),
+                        'invert' => false,
+                    ],
+                    [
+                        'id'     => 'depressivität',
+                        'text'   => __( 'Wie stark fühlst Du Dich heute von depressiven Gedanken oder Gefühlen belastet?', 'mecfs-tracker' ),
+                        'scale'  => __( '1 = überhaupt nicht, 10 = sehr stark', 'mecfs-tracker' ),
+                        'invert' => true,
+                    ],
+                ];
+                foreach ( $emotion_questions as $q ) :
+                    ?>
+                    <div class="emotion-question">
+                        <label for="emotion-<?php echo esc_attr( $q['id'] ); ?>"><?php echo esc_html( $q['text'] ); ?></label>
+                        <input type="range" name="emotion[<?php echo esc_attr( $q['id'] ); ?>]" id="emotion-<?php echo esc_attr( $q['id'] ); ?>" min="1" max="10" value="5" />
+                        <span class="range-value">5</span>
+                        <div class="slider-scale"><span>1</span><span>10</span></div>
+                        <small><?php echo esc_html( $q['scale'] ); ?></small>
+                    </div>
+                    <?php
+                endforeach;
+                ?>
+            </div>
+            <input type="hidden" name="emotion" value="0" />
             <div id="symptom-list">
                 <h4><?php esc_html_e( 'Symptome', 'mecfs-tracker' ); ?></h4>
-                <?php foreach ( $symptoms as $symptom ) : ?>
-                    <div class="symptom-field">
-                        <span><?php echo esc_html( $symptom->label ); ?></span>
-                        <input type="range" name="symptoms[<?php echo intval( $symptom->id ); ?>]" min="0" max="100" />
-                    </div>
-                <?php endforeach; ?>
-                <div id="custom-symptoms"></div>
+                <table class="symptom-table">
+                    <tbody id="symptom-table-body">
+                        <?php foreach ( $symptoms as $symptom ) : ?>
+                            <tr class="symptom-field">
+                                <td><?php echo esc_html( $symptom->label ); ?></td>
+                                <td>
+                                    <input type="range" name="symptoms[<?php echo intval( $symptom->id ); ?>]" min="0" max="100" value="0" />
+                                    <span class="range-value">0</span>
+                                    <div class="slider-scale"><span>0</span><span>100</span></div>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
                 <button type="button" id="add-symptom"><?php esc_html_e( 'Symptom hinzufügen', 'mecfs-tracker' ); ?></button>
             </div>
             <textarea name="notes" placeholder="<?php esc_attr_e( 'Besonderheiten', 'mecfs-tracker' ); ?>"></textarea>


### PR DESCRIPTION
## Summary
- Replace single emotional-state slider with four detailed range questions and compute a normalized 0-100 score.
- Display symptom sliders in a tidy table and show numeric scales for all ranges.
- Style new form sections and synchronize slider values via JavaScript.

## Testing
- `php -l includes/class-frontend-form.php`
- `node --check assets/form.js`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894d7c8a1a4832eb7f2ee79dc224a33