### PR TITLE
Improve form layout and document emotion scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ WordPress-Plugin zum täglichen Erfassen von Bell-Score, emotionalem Zustand, in
 ## Bell-Score und emotionaler Zustand
 Der Bell-Score beschreibt die allgemeine Belastbarkeit auf einer Skala von 0–100. Im Formular wird er über einen kurzen Fragebogen ermittelt. 
 
-Der emotionale Zustand wird weiterhin über einen Schieberegler von 0–100 erfasst.
+Der emotionale Zustand wird über vier Schieberegler zu Angst, Stimmung, Antrieb und Depressivität erfasst. Jeder Regler reicht von 1 bis 10, zwei Fragen (Ängste, Depressivität) werden für die Auswertung invertiert.
 
-### Berechnungsgrundlage
+### Berechnungsgrundlage Bell-Score
 Der Fragebogen besteht aus fünf Fragen, die jeweils von 0 (schlechtester Zustand) bis 4 (bester Zustand) bewertet werden:
 
 1. Wie belastbar fühlen Sie sich heute körperlich?
@@ -32,6 +32,22 @@ Die Antworten werden summiert, durch die maximale Punktzahl (5 Fragen × 4 Punkt
 ```
 Bell-Score = (Summe der Antworten / 20) × 100
 ```
+
+### Berechnungsgrundlage emotionaler Zustand
+Die vier Fragen zum emotionalen Zustand sind:
+
+1. Wie stark fühlst Du Dich heute von Ängsten oder Sorgen belastet? *(invertiert)*
+2. Wie ist Deine allgemeine Stimmung heute?
+3. Wie stark ist Dein innerer Antrieb heute?
+4. Wie stark fühlst Du Dich heute von depressiven Gedanken oder Gefühlen belastet? *(invertiert)*
+
+Die Antworten liegen zwischen 1 und 10 Punkten. Bei invertierten Fragen wird der Wert mit `10 - Antwort` umgerechnet. Anschließend wird die Summe auf eine Skala von 0–100 normiert:
+
+```
+Emotion = ((Summe - Min) / (Max - Min)) × 100
+```
+
+Dabei ist `Min` die Anzahl der nicht invertierten Fragen × 1 und `Max` die Anzahl der invertierten Fragen × 9 plus die Anzahl der nicht invertierten Fragen × 10.
 
 ## Entwicklung und Build
 

--- a/assets/mecfs-tracker.css
+++ b/assets/mecfs-tracker.css
@@ -1,49 +1,117 @@
+/* Container */
 #mecfs-tracker-form {
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    max-width: 480px;
+    margin: 1rem auto;
+    padding: 1rem;
+    border-radius: 20px;
+    background: #f2f2f7;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 16px;
 }
-.bell-question {
+
+/* General inputs */
+#mecfs-tracker-form input[type="date"],
+#mecfs-tracker-form input[type="text"],
+#mecfs-tracker-form textarea {
+    width: 100%;
+    padding: 0.75rem 1rem;
     border: 1px solid #ccc;
-    padding: 0.5rem;
+    border-radius: 12px;
+    background: #fff;
+    font-size: 1rem;
 }
-.bell-question label {
+
+#mecfs-tracker-form textarea {
+    min-height: 80px;
+}
+
+/* Card style sections */
+.bell-question,
+.emotion-question,
+#symptom-list,
+#mecfs-tracker-form textarea,
+#mecfs-tracker-form input[type="date"] {
+    background: #fff;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    padding: 1rem;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+.bell-question legend {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.bell-question label,
+.emotion-question label {
     display: block;
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.5rem;
+    font-size: 0.95rem;
 }
+
 #emotion-questions {
     display: flex;
     flex-direction: column;
     gap: 1rem;
 }
-.emotion-question {
-    border: 1px solid #ccc;
-    padding: 0.5rem;
-}
-.emotion-question label {
-    display: block;
-    margin-bottom: 0.25rem;
-}
-.symptom-table {
-    width: 100%;
-    border-collapse: collapse;
-}
-.symptom-table td {
-    padding: 0.25rem;
-    vertical-align: middle;
-}
+
+/* Sliders */
 .slider-scale {
     display: flex;
     justify-content: space-between;
     font-size: 0.75rem;
+    color: #666;
 }
+
 .range-value {
     margin-left: 0.5rem;
+    font-weight: 600;
 }
+
+/* Symptom table */
+.symptom-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0 0.5rem;
+}
+
+.symptom-table td {
+    padding: 0.5rem;
+    vertical-align: middle;
+}
+
+.symptom-table td:first-child {
+    width: 40%;
+}
+
+/* Buttons */
+#mecfs-tracker-form button {
+    padding: 0.75rem 1rem;
+    border: none;
+    border-radius: 12px;
+    font-size: 1rem;
+}
+
+#mecfs-tracker-form button[type="submit"] {
+    background: #007aff;
+    color: #fff;
+}
+
+#mecfs-tracker-form button#add-symptom {
+    background: #f2f2f7;
+    color: #007aff;
+    border: 1px solid #007aff;
+}
+
 #mecfs-tracker-chart {
     max-width: 100%;
     margin-top: 1rem;
 }
+
 #mecfs-export {
     margin-top: 1rem;
 }


### PR DESCRIPTION
## Summary
- restyle tracker form with iOS-inspired cards, fonts and buttons for better readability
- document detailed emotional state scoring in README

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6894dc731144832eb8f9d9ff19aaee85