### PR TITLE
Convert radio buttons to Bootstrap dropdowns

### DIFF
--- a/assets/form.js
+++ b/assets/form.js
@@ -14,7 +14,7 @@ jQuery(function ($) {
 
     let symptomIndex = 0;
     $('#add-symptom').on('click', function () {
-        const row = $('<tr class="symptom-field"><td><input type="text" name="new_symptoms[' + symptomIndex + '][label]" placeholder="Symptom" /></td><td><input type="range" name="new_symptoms[' + symptomIndex + '][severity]" min="0" max="100" value="0" /><span class="range-value">0</span><div class="slider-scale"><span>0</span><span>100</span></div></td></tr>');
+        const row = $('<tr class="symptom-field"><td><input type="text" class="form-control" name="new_symptoms[' + symptomIndex + '][label]" placeholder="Symptom" /></td><td><input type="range" class="form-range" name="new_symptoms[' + symptomIndex + '][severity]" min="0" max="100" value="0" /><span class="range-value">0</span><div class="slider-scale"><span>0</span><span>100</span></div></td></tr>');
         $('#symptom-table-body').append(row);
         addRangeListeners(row);
         symptomIndex++;
@@ -25,7 +25,7 @@ jQuery(function ($) {
         let sum = 0;
         const questions = 4;
         for (let i = 1; i <= questions; i++) {
-            const val = parseInt($('input[name="bell_q' + i + '"]:checked').val(), 10);
+            const val = parseInt($('select[name="bell_q' + i + '"]').val(), 10);
             if (isNaN(val)) {
                 alert('Bitte alle Fragen beantworten.');
                 return;

--- a/assets/mecfs-tracker.css
+++ b/assets/mecfs-tracker.css
@@ -6,57 +6,8 @@
     max-width: 480px;
     margin: 1rem auto;
     padding: 1rem;
-    border-radius: 20px;
-    background: #f2f2f7;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    font-size: 16px;
-}
-
-/* General inputs */
-#mecfs-tracker-form input[type="date"],
-#mecfs-tracker-form input[type="text"],
-#mecfs-tracker-form textarea {
-    width: 100%;
-    padding: 0.75rem 1rem;
-    border: 1px solid #ccc;
-    border-radius: 12px;
-    background: #fff;
-    font-size: 1rem;
-}
-
-#mecfs-tracker-form textarea {
-    min-height: 80px;
-}
-
-/* Card style sections */
-.bell-question,
-.emotion-question,
-#symptom-list,
-#mecfs-tracker-form textarea,
-#mecfs-tracker-form input[type="date"] {
-    background: #fff;
-    border: 1px solid #e0e0e0;
-    border-radius: 12px;
-    padding: 1rem;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-}
-
-.bell-question legend {
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-}
-
-.bell-question label,
-.emotion-question label {
-    display: block;
-    margin-bottom: 0.5rem;
-    font-size: 0.95rem;
-}
-
-#emotion-questions {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
+    color: inherit;
+    font-family: inherit;
 }
 
 /* Sliders */
@@ -64,7 +15,7 @@
     display: flex;
     justify-content: space-between;
     font-size: 0.75rem;
-    color: #666;
+    color: var(--bs-secondary-color);
 }
 
 .range-value {
@@ -86,32 +37,4 @@
 
 .symptom-table td:first-child {
     width: 40%;
-}
-
-/* Buttons */
-#mecfs-tracker-form button {
-    padding: 0.75rem 1rem;
-    border: none;
-    border-radius: 12px;
-    font-size: 1rem;
-}
-
-#mecfs-tracker-form button[type="submit"] {
-    background: #007aff;
-    color: #fff;
-}
-
-#mecfs-tracker-form button#add-symptom {
-    background: #f2f2f7;
-    color: #007aff;
-    border: 1px solid #007aff;
-}
-
-#mecfs-tracker-chart {
-    max-width: 100%;
-    margin-top: 1rem;
-}
-
-#mecfs-export {
-    margin-top: 1rem;
 }

--- a/blocks/chart/index.asset.php
+++ b/blocks/chart/index.asset.php
@@ -1,5 +1,1 @@
-<?php
-return array(
-    'dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n'),
-    'version' => '0.1.1',
-);
+<?php return array('dependencies' => array(), 'version' => '422729c742ff72b78164');

--- a/blocks/chart/index.js
+++ b/blocks/chart/index.js
@@ -1,17 +1,1 @@
-( function( blocks, element, i18n ) {
-    const { registerBlockType } = blocks;
-    const { createElement } = element;
-    const { __ } = i18n;
-
-    registerBlockType( 'mecfs/chart', {
-        title: __( 'MECFS Tracker Diagramm', 'mecfs-tracker' ),
-        icon: 'chart-bar',
-        category: 'widgets',
-        edit: function() {
-            return createElement( 'p', {}, __( 'MECFS Tracker Diagramm', 'mecfs-tracker' ) );
-        },
-        save: function() {
-            return null;
-        }
-    } );
-} )( window.wp.blocks, window.wp.element, window.wp.i18n );
+!function(e,r,t){const{registerBlockType:c}=e,{createElement:n}=r,{__}=t;c("mecfs/chart",{title:__("MECFS Tracker Diagramm","mecfs-tracker"),icon:"chart-bar",category:"widgets",edit:function(){return n("p",{},__("MECFS Tracker Diagramm","mecfs-tracker"))},save:function(){return null}})}(window.wp.blocks,window.wp.element,window.wp.i18n);

--- a/blocks/export/index.asset.php
+++ b/blocks/export/index.asset.php
@@ -1,5 +1,1 @@
-<?php
-return array(
-    'dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n'),
-    'version' => '0.1.1',
-);
+<?php return array('dependencies' => array(), 'version' => '45d1e8692ad539dc336b');

--- a/blocks/export/index.js
+++ b/blocks/export/index.js
@@ -1,17 +1,1 @@
-( function( blocks, element, i18n ) {
-    const { registerBlockType } = blocks;
-    const { createElement } = element;
-    const { __ } = i18n;
-
-    registerBlockType( 'mecfs/export', {
-        title: __( 'MECFS Export-Button', 'mecfs-tracker' ),
-        icon: 'download',
-        category: 'widgets',
-        edit: function() {
-            return createElement( 'p', {}, __( 'MECFS Export-Button', 'mecfs-tracker' ) );
-        },
-        save: function() {
-            return null;
-        }
-    } );
-} )( window.wp.blocks, window.wp.element, window.wp.i18n );
+!function(t,e,n){const{registerBlockType:o}=t,{createElement:r}=e,{__}=n;o("mecfs/export",{title:__("MECFS Export-Button","mecfs-tracker"),icon:"download",category:"widgets",edit:function(){return r("p",{},__("MECFS Export-Button","mecfs-tracker"))},save:function(){return null}})}(window.wp.blocks,window.wp.element,window.wp.i18n);

--- a/blocks/form/index.asset.php
+++ b/blocks/form/index.asset.php
@@ -1,5 +1,1 @@
-<?php
-return array(
-    'dependencies' => array('wp-blocks', 'wp-element', 'wp-i18n'),
-    'version' => '0.1.1',
-);
+<?php return array('dependencies' => array(), 'version' => '2dd8d54fb7b6881502df');

--- a/blocks/form/index.js
+++ b/blocks/form/index.js
@@ -1,17 +1,1 @@
-( function( blocks, element, i18n ) {
-    const { registerBlockType } = blocks;
-    const { createElement } = element;
-    const { __ } = i18n;
-
-    registerBlockType( 'mecfs/form', {
-        title: __( 'MECFS Tracker Formular', 'mecfs-tracker' ),
-        icon: 'clipboard',
-        category: 'widgets',
-        edit: function() {
-            return createElement( 'p', {}, __( 'MECFS Tracker Formular', 'mecfs-tracker' ) );
-        },
-        save: function() {
-            return null;
-        }
-    } );
-} )( window.wp.blocks, window.wp.element, window.wp.i18n );
+!function(e,r,c){const{registerBlockType:n}=e,{createElement:t}=r,{__}=c;n("mecfs/form",{title:__("MECFS Tracker Formular","mecfs-tracker"),icon:"clipboard",category:"widgets",edit:function(){return t("p",{},__("MECFS Tracker Formular","mecfs-tracker"))},save:function(){return null}})}(window.wp.blocks,window.wp.element,window.wp.i18n);

--- a/includes/class-frontend-form.php
+++ b/includes/class-frontend-form.php
@@ -32,8 +32,8 @@ class Frontend_Form {
         $symptoms      = $wpdb->get_results( "SELECT id, label FROM $symptom_table ORDER BY label" );
         ob_start();
         ?>
-        <form id="mecfs-tracker-form">
-            <input type="date" name="entry_date" value="<?php echo esc_attr( current_time( 'Y-m-d' ) ); ?>" />
+        <form id="mecfs-tracker-form" class="d-flex flex-column gap-3">
+            <input type="date" class="form-control" name="entry_date" value="<?php echo esc_attr( current_time( 'Y-m-d' ) ); ?>" />
             <?php
             $questions = [
                 [
@@ -75,17 +75,24 @@ class Frontend_Form {
             ];
             foreach ( $questions as $index => $data ) :
                 ?>
-                <fieldset class="bell-question">
-                    <legend><?php echo esc_html( $data['question'] ); ?></legend>
-                    <?php foreach ( $data['options'] as $option ) : ?>
-                        <label><input type="radio" name="bell_q<?php echo $index + 1; ?>" value="<?php echo esc_attr( $option['value'] ); ?>" required /> <?php echo esc_html( $option['label'] ); ?> &rarr; <?php echo intval( $option['value'] ); ?> <?php esc_html_e( 'Punkte', 'mecfs-tracker' ); ?></label>
-                    <?php endforeach; ?>
-                </fieldset>
+                <div class="card bell-question">
+                    <div class="card-body">
+                        <label for="bell_q<?php echo $index + 1; ?>" class="form-label"><?php echo esc_html( $data['question'] ); ?></label>
+                        <select class="form-select" id="bell_q<?php echo $index + 1; ?>" name="bell_q<?php echo $index + 1; ?>" required>
+                            <option value="" selected disabled><?php esc_html_e( 'Bitte auswählen', 'mecfs-tracker' ); ?></option>
+                            <?php foreach ( $data['options'] as $option ) : ?>
+                                <option value="<?php echo esc_attr( $option['value'] ); ?>">
+                                    <?php echo esc_html( $option['label'] ); ?> &rarr; <?php echo intval( $option['value'] ); ?> <?php esc_html_e( 'Punkte', 'mecfs-tracker' ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                </div>
                 <?php
             endforeach;
             ?>
             <input type="hidden" name="bell_score" value="0" />
-            <div id="emotion-questions">
+            <div id="emotion-questions" class="d-flex flex-column gap-3">
                 <h4><?php esc_html_e( 'Emotionaler Zustand', 'mecfs-tracker' ); ?></h4>
                 <?php
                 $emotion_questions = [
@@ -116,40 +123,44 @@ class Frontend_Form {
                 ];
                 foreach ( $emotion_questions as $q ) :
                     ?>
-                    <div class="emotion-question">
-                        <label for="emotion-<?php echo esc_attr( $q['id'] ); ?>"><?php echo esc_html( $q['text'] ); ?></label>
-                        <input type="range" name="emotion[<?php echo esc_attr( $q['id'] ); ?>]" id="emotion-<?php echo esc_attr( $q['id'] ); ?>" min="1" max="10" value="5" />
-                        <span class="range-value">5</span>
-                        <div class="slider-scale"><span>1</span><span>10</span></div>
-                        <small><?php echo esc_html( $q['scale'] ); ?></small>
+                    <div class="emotion-question card">
+                        <div class="card-body">
+                            <label for="emotion-<?php echo esc_attr( $q['id'] ); ?>" class="form-label"><?php echo esc_html( $q['text'] ); ?></label>
+                            <input type="range" class="form-range" name="emotion[<?php echo esc_attr( $q['id'] ); ?>]" id="emotion-<?php echo esc_attr( $q['id'] ); ?>" min="1" max="10" value="5" />
+                            <span class="range-value">5</span>
+                            <div class="slider-scale"><span>1</span><span>10</span></div>
+                            <small class="text-muted"><?php echo esc_html( $q['scale'] ); ?></small>
+                        </div>
                     </div>
                     <?php
                 endforeach;
                 ?>
             </div>
             <input type="hidden" name="emotion" value="0" />
-            <div id="symptom-list">
-                <h4><?php esc_html_e( 'Symptome', 'mecfs-tracker' ); ?></h4>
-                <table class="symptom-table">
-                    <tbody id="symptom-table-body">
-                        <?php foreach ( $symptoms as $symptom ) : ?>
-                            <tr class="symptom-field">
-                                <td><?php echo esc_html( $symptom->label ); ?></td>
-                                <td>
-                                    <input type="range" name="symptoms[<?php echo intval( $symptom->id ); ?>]" min="0" max="100" value="0" />
-                                    <span class="range-value">0</span>
-                                    <div class="slider-scale"><span>0</span><span>100</span></div>
-                                </td>
-                            </tr>
-                        <?php endforeach; ?>
-                    </tbody>
-                </table>
-                <button type="button" id="add-symptom"><?php esc_html_e( 'Symptom hinzufügen', 'mecfs-tracker' ); ?></button>
+            <div id="symptom-list" class="card">
+                <div class="card-body">
+                    <h4><?php esc_html_e( 'Symptome', 'mecfs-tracker' ); ?></h4>
+                    <table class="symptom-table table">
+                        <tbody id="symptom-table-body">
+                            <?php foreach ( $symptoms as $symptom ) : ?>
+                                <tr class="symptom-field">
+                                    <td><?php echo esc_html( $symptom->label ); ?></td>
+                                    <td>
+                                        <input type="range" class="form-range" name="symptoms[<?php echo intval( $symptom->id ); ?>]" min="0" max="100" value="0" />
+                                        <span class="range-value">0</span>
+                                        <div class="slider-scale"><span>0</span><span>100</span></div>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                    <button type="button" id="add-symptom" class="btn btn-outline-primary"><?php esc_html_e( 'Symptom hinzufügen', 'mecfs-tracker' ); ?></button>
+                </div>
             </div>
-            <textarea name="notes" placeholder="<?php esc_attr_e( 'Besonderheiten', 'mecfs-tracker' ); ?>"></textarea>
-            <textarea name="positives" placeholder="<?php esc_attr_e( 'Was hat gutgetan?', 'mecfs-tracker' ); ?>"></textarea>
-            <textarea name="negatives" placeholder="<?php esc_attr_e( 'Was hat belastet?', 'mecfs-tracker' ); ?>"></textarea>
-            <button type="submit"><?php esc_html_e( 'Speichern', 'mecfs-tracker' ); ?></button>
+            <textarea class="form-control" name="notes" placeholder="<?php esc_attr_e( 'Besonderheiten', 'mecfs-tracker' ); ?>"></textarea>
+            <textarea class="form-control" name="positives" placeholder="<?php esc_attr_e( 'Was hat gutgetan?', 'mecfs-tracker' ); ?>"></textarea>
+            <textarea class="form-control" name="negatives" placeholder="<?php esc_attr_e( 'Was hat belastet?', 'mecfs-tracker' ); ?>"></textarea>
+            <button type="submit" class="btn btn-primary"><?php esc_html_e( 'Speichern', 'mecfs-tracker' ); ?></button>
         </form>
         <?php
         return ob_get_clean();

--- a/mecfs-tracker.php
+++ b/mecfs-tracker.php
@@ -16,6 +16,8 @@ define( 'MECFS_TRACKER_PLUGIN_FILE', __FILE__ );
 require_once __DIR__ . '/includes/autoloader.php';
 
 add_action( 'wp_enqueue_scripts', function() {
+    wp_enqueue_style( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css', [], '5.3.3' );
+    wp_enqueue_script( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js', [], '5.3.3', true );
     wp_enqueue_style( 'mecfs-tracker', plugins_url( 'assets/mecfs-tracker.css', __FILE__ ), [], MECFS_TRACKER_VERSION );
 } );
 


### PR DESCRIPTION
## Summary
- Replace fieldsets with Bootstrap cards and convert radio inputs to dropdowns
- Enqueue Bootstrap 5 assets and apply Bootstrap classes across the form
- Simplify CSS to inherit theme typography and colors

## Testing
- `php -l mecfs-tracker.php`
- `php -l includes/class-frontend-form.php`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895749ee630832ebe675cfe863d5981