### PR TITLE
Conditionally load Bootstrap to avoid theme conflicts

### DIFF
--- a/mecfs-tracker.php
+++ b/mecfs-tracker.php
@@ -16,9 +16,12 @@ define( 'MECFS_TRACKER_PLUGIN_FILE', __FILE__ );
 require_once __DIR__ . '/includes/autoloader.php';
 
 add_action( 'wp_enqueue_scripts', function() {
-    wp_enqueue_style( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css', [], '5.3.3' );
-    wp_enqueue_script( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js', [], '5.3.3', true );
-    wp_enqueue_style( 'mecfs-tracker', plugins_url( 'assets/mecfs-tracker.css', __FILE__ ), [], MECFS_TRACKER_VERSION );
+    $post = get_post();
+    if ( $post && ( has_block( 'mecfs-tracker/form', $post ) || has_block( 'mecfs-tracker/export', $post ) || has_block( 'mecfs-tracker/chart', $post ) ) ) {
+        wp_enqueue_style( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css', [], '5.3.3' );
+        wp_enqueue_script( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js', [], '5.3.3', true );
+        wp_enqueue_style( 'mecfs-tracker', plugins_url( 'assets/mecfs-tracker.css', __FILE__ ), [ 'bootstrap' ], MECFS_TRACKER_VERSION );
+    }
 } );
 
 if ( ! function_exists( 'mecfs_tracker_run' ) ) {


### PR DESCRIPTION
## Summary
- Load Bootstrap only when MECFS Tracker blocks are present
- Ensure plugin stylesheet depends on Bootstrap for correct order

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689577e9b8b8832eab17343b05305179