### PR TITLE
refactor: remove bootstrap and namespace styles

### DIFF
--- a/assets/form.js
+++ b/assets/form.js
@@ -14,7 +14,7 @@ jQuery(function ($) {
 
     let symptomIndex = 0;
     $('#add-symptom').on('click', function () {
-        const row = $('<tr class="symptom-field"><td><input type="text" class="form-control" name="new_symptoms[' + symptomIndex + '][label]" placeholder="Symptom" /></td><td><input type="range" class="form-range" name="new_symptoms[' + symptomIndex + '][severity]" min="0" max="100" value="0" /><span class="range-value">0</span><div class="slider-scale"><span>0</span><span>100</span></div></td></tr>');
+        const row = $('<tr class="symptom-field"><td><input type="text" class="mecfs-form-control" name="new_symptoms[' + symptomIndex + '][label]" placeholder="Symptom" /></td><td><input type="range" class="mecfs-form-range" name="new_symptoms[' + symptomIndex + '][severity]" min="0" max="100" value="0" /><span class="range-value">0</span><div class="slider-scale"><span>0</span><span>100</span></div></td></tr>');
         $('#symptom-table-body').append(row);
         addRangeListeners(row);
         symptomIndex++;

--- a/assets/mecfs-tracker.css
+++ b/assets/mecfs-tracker.css
@@ -1,3 +1,11 @@
+/* Variables */
+:root {
+    --mecfs-primary: #0d6efd;
+    --mecfs-secondary-color: #6c757d;
+    --mecfs-border-color: #dee2e6;
+    --mecfs-border-radius: 0.375rem;
+}
+
 /* Container */
 #mecfs-tracker-form {
     display: flex;
@@ -10,12 +18,135 @@
     font-family: inherit;
 }
 
+#emotion-questions {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+/* Cards */
+#mecfs-tracker-form .mecfs-card {
+    border: 1px solid var(--mecfs-border-color);
+    border-radius: var(--mecfs-border-radius);
+}
+
+#mecfs-tracker-form .mecfs-card-body {
+    padding: 1rem;
+}
+
+/* Buttons */
+#mecfs-tracker-form .mecfs-btn {
+    display: inline-block;
+    font-weight: 400;
+    line-height: 1.5;
+    text-align: center;
+    cursor: pointer;
+    user-select: none;
+    border: 1px solid transparent;
+    padding: 0.375rem 0.75rem;
+    font-size: 1rem;
+    border-radius: var(--mecfs-border-radius);
+    transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+
+#mecfs-tracker-form .mecfs-btn-primary {
+    color: #fff;
+    background-color: var(--mecfs-primary);
+    border-color: var(--mecfs-primary);
+}
+
+#mecfs-tracker-form .mecfs-btn-primary:hover {
+    background-color: #0b5ed7;
+    border-color: #0a58ca;
+}
+
+#mecfs-tracker-form .mecfs-btn-outline-primary {
+    color: var(--mecfs-primary);
+    background-color: transparent;
+    border-color: var(--mecfs-primary);
+}
+
+#mecfs-tracker-form .mecfs-btn-outline-primary:hover {
+    color: #fff;
+    background-color: var(--mecfs-primary);
+}
+
+/* Form controls */
+#mecfs-tracker-form .mecfs-form-control,
+#mecfs-tracker-form .mecfs-form-select {
+    display: block;
+    width: 100%;
+    padding: 0.375rem 0.75rem;
+    font: inherit;
+    line-height: 1.5;
+    color: inherit;
+    background-color: #fff;
+    border: 1px solid var(--mecfs-border-color);
+    border-radius: var(--mecfs-border-radius);
+}
+
+#mecfs-tracker-form .mecfs-form-range {
+    width: 100%;
+    height: 1.5rem;
+    padding: 0;
+    background-color: transparent;
+    appearance: none;
+}
+
+#mecfs-tracker-form .mecfs-form-range:focus {
+    outline: none;
+}
+
+#mecfs-tracker-form .mecfs-form-range::-webkit-slider-thumb {
+    width: 1rem;
+    height: 1rem;
+    background-color: var(--mecfs-primary);
+    border: 0;
+    border-radius: 1rem;
+    appearance: none;
+}
+
+#mecfs-tracker-form .mecfs-form-range::-webkit-slider-runnable-track {
+    width: 100%;
+    height: 0.5rem;
+    background-color: var(--mecfs-border-color);
+    border-radius: 1rem;
+    cursor: pointer;
+}
+
+#mecfs-tracker-form .mecfs-form-range::-moz-range-thumb {
+    width: 1rem;
+    height: 1rem;
+    background-color: var(--mecfs-primary);
+    border: 0;
+    border-radius: 1rem;
+}
+
+#mecfs-tracker-form .mecfs-form-range::-moz-range-track {
+    width: 100%;
+    height: 0.5rem;
+    background-color: var(--mecfs-border-color);
+    border-radius: 1rem;
+    cursor: pointer;
+}
+
+#mecfs-tracker-form .mecfs-form-label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+
+#mecfs-tracker-form .mecfs-text-muted {
+    color: var(--mecfs-secondary-color);
+    font-size: 0.875rem;
+}
+
 /* Sliders */
 .slider-scale {
     display: flex;
     justify-content: space-between;
     font-size: 0.75rem;
-    color: var(--bs-secondary-color);
+    color: var(--mecfs-secondary-color);
 }
 
 .range-value {

--- a/includes/class-frontend-form.php
+++ b/includes/class-frontend-form.php
@@ -32,8 +32,8 @@ class Frontend_Form {
         $symptoms      = $wpdb->get_results( "SELECT id, label FROM $symptom_table ORDER BY label" );
         ob_start();
         ?>
-        <form id="mecfs-tracker-form" class="d-flex flex-column gap-3">
-            <input type="date" class="form-control" name="entry_date" value="<?php echo esc_attr( current_time( 'Y-m-d' ) ); ?>" />
+        <form id="mecfs-tracker-form">
+            <input type="date" class="mecfs-form-control" name="entry_date" value="<?php echo esc_attr( current_time( 'Y-m-d' ) ); ?>" />
             <?php
             $questions = [
                 [
@@ -75,10 +75,10 @@ class Frontend_Form {
             ];
             foreach ( $questions as $index => $data ) :
                 ?>
-                <div class="card bell-question">
-                    <div class="card-body">
-                        <label for="bell_q<?php echo $index + 1; ?>" class="form-label"><?php echo esc_html( $data['question'] ); ?></label>
-                        <select class="form-select" id="bell_q<?php echo $index + 1; ?>" name="bell_q<?php echo $index + 1; ?>" required>
+                <div class="mecfs-card bell-question">
+                    <div class="mecfs-card-body">
+                        <label for="bell_q<?php echo $index + 1; ?>" class="mecfs-form-label"><?php echo esc_html( $data['question'] ); ?></label>
+                        <select class="mecfs-form-select" id="bell_q<?php echo $index + 1; ?>" name="bell_q<?php echo $index + 1; ?>" required>
                             <option value="" selected disabled><?php esc_html_e( 'Bitte auswählen', 'mecfs-tracker' ); ?></option>
                             <?php foreach ( $data['options'] as $option ) : ?>
                                 <option value="<?php echo esc_attr( $option['value'] ); ?>">
@@ -92,7 +92,7 @@ class Frontend_Form {
             endforeach;
             ?>
             <input type="hidden" name="bell_score" value="0" />
-            <div id="emotion-questions" class="d-flex flex-column gap-3">
+            <div id="emotion-questions">
                 <h4><?php esc_html_e( 'Emotionaler Zustand', 'mecfs-tracker' ); ?></h4>
                 <?php
                 $emotion_questions = [
@@ -123,13 +123,13 @@ class Frontend_Form {
                 ];
                 foreach ( $emotion_questions as $q ) :
                     ?>
-                    <div class="emotion-question card">
-                        <div class="card-body">
-                            <label for="emotion-<?php echo esc_attr( $q['id'] ); ?>" class="form-label"><?php echo esc_html( $q['text'] ); ?></label>
-                            <input type="range" class="form-range" name="emotion[<?php echo esc_attr( $q['id'] ); ?>]" id="emotion-<?php echo esc_attr( $q['id'] ); ?>" min="1" max="10" value="5" />
+                    <div class="emotion-question mecfs-card">
+                        <div class="mecfs-card-body">
+                            <label for="emotion-<?php echo esc_attr( $q['id'] ); ?>" class="mecfs-form-label"><?php echo esc_html( $q['text'] ); ?></label>
+                            <input type="range" class="mecfs-form-range" name="emotion[<?php echo esc_attr( $q['id'] ); ?>]" id="emotion-<?php echo esc_attr( $q['id'] ); ?>" min="1" max="10" value="5" />
                             <span class="range-value">5</span>
                             <div class="slider-scale"><span>1</span><span>10</span></div>
-                            <small class="text-muted"><?php echo esc_html( $q['scale'] ); ?></small>
+                            <small class="mecfs-text-muted"><?php echo esc_html( $q['scale'] ); ?></small>
                         </div>
                     </div>
                     <?php
@@ -137,16 +137,16 @@ class Frontend_Form {
                 ?>
             </div>
             <input type="hidden" name="emotion" value="0" />
-            <div id="symptom-list" class="card">
-                <div class="card-body">
+            <div id="symptom-list" class="mecfs-card">
+                <div class="mecfs-card-body">
                     <h4><?php esc_html_e( 'Symptome', 'mecfs-tracker' ); ?></h4>
-                    <table class="symptom-table table">
+                    <table class="symptom-table">
                         <tbody id="symptom-table-body">
                             <?php foreach ( $symptoms as $symptom ) : ?>
                                 <tr class="symptom-field">
                                     <td><?php echo esc_html( $symptom->label ); ?></td>
                                     <td>
-                                        <input type="range" class="form-range" name="symptoms[<?php echo intval( $symptom->id ); ?>]" min="0" max="100" value="0" />
+                                        <input type="range" class="mecfs-form-range" name="symptoms[<?php echo intval( $symptom->id ); ?>]" min="0" max="100" value="0" />
                                         <span class="range-value">0</span>
                                         <div class="slider-scale"><span>0</span><span>100</span></div>
                                     </td>
@@ -154,13 +154,13 @@ class Frontend_Form {
                             <?php endforeach; ?>
                         </tbody>
                     </table>
-                    <button type="button" id="add-symptom" class="btn btn-outline-primary"><?php esc_html_e( 'Symptom hinzufügen', 'mecfs-tracker' ); ?></button>
+                    <button type="button" id="add-symptom" class="mecfs-btn mecfs-btn-outline-primary"><?php esc_html_e( 'Symptom hinzufügen', 'mecfs-tracker' ); ?></button>
                 </div>
             </div>
-            <textarea class="form-control" name="notes" placeholder="<?php esc_attr_e( 'Besonderheiten', 'mecfs-tracker' ); ?>"></textarea>
-            <textarea class="form-control" name="positives" placeholder="<?php esc_attr_e( 'Was hat gutgetan?', 'mecfs-tracker' ); ?>"></textarea>
-            <textarea class="form-control" name="negatives" placeholder="<?php esc_attr_e( 'Was hat belastet?', 'mecfs-tracker' ); ?>"></textarea>
-            <button type="submit" class="btn btn-primary"><?php esc_html_e( 'Speichern', 'mecfs-tracker' ); ?></button>
+            <textarea class="mecfs-form-control" name="notes" placeholder="<?php esc_attr_e( 'Besonderheiten', 'mecfs-tracker' ); ?>"></textarea>
+            <textarea class="mecfs-form-control" name="positives" placeholder="<?php esc_attr_e( 'Was hat gutgetan?', 'mecfs-tracker' ); ?>"></textarea>
+            <textarea class="mecfs-form-control" name="negatives" placeholder="<?php esc_attr_e( 'Was hat belastet?', 'mecfs-tracker' ); ?>"></textarea>
+            <button type="submit" class="mecfs-btn mecfs-btn-primary"><?php esc_html_e( 'Speichern', 'mecfs-tracker' ); ?></button>
         </form>
         <?php
         return ob_get_clean();

--- a/mecfs-tracker.php
+++ b/mecfs-tracker.php
@@ -16,13 +16,7 @@ define( 'MECFS_TRACKER_PLUGIN_FILE', __FILE__ );
 require_once __DIR__ . '/includes/autoloader.php';
 
 add_action( 'wp_enqueue_scripts', function() {
-
-    wp_enqueue_style( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css', [], '5.3.3' );
-}, 1 );
-
-add_action( 'wp_enqueue_scripts', function() {
-    wp_enqueue_script( 'bootstrap', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js', [], '5.3.3', true );
-    wp_enqueue_style( 'mecfs-tracker', plugins_url( 'assets/mecfs-tracker.css', __FILE__ ), [ 'bootstrap' ], MECFS_TRACKER_VERSION );
+    wp_enqueue_style( 'mecfs-tracker', plugins_url( 'assets/mecfs-tracker.css', __FILE__ ), [], MECFS_TRACKER_VERSION );
 }, 11 );
 
    


### PR DESCRIPTION
## Summary
- remove Bootstrap assets and enqueue only plugin CSS
- replace Bootstrap classes with plugin-scoped equivalents
- add custom styles to mimic Bootstrap look without affecting themes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689581949660832e921ba52d953213db